### PR TITLE
qol: add builddir to path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Nix with flakes enabled.
   
 1. Enter dev shell and generate build files
 ```sh
-nix develop
+nix develop # skip this if you have direnv
 meson setup build --buildtype=debug # debug build
 # OR
 meson setup build --buildtype=release # release build
@@ -32,7 +32,7 @@ meson compile -C build tidy # run clang-tidy
 
 3. Run
 ```sh
-./build/daisyc main.daisy utils.daisy -o program
+daisyc main.daisy utils.daisy -o program
 ```
   
 This project uses Google Test. Run tests with `meson test -C build`.  

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,7 @@
           shellHook = ''
             export CXX=clang++
             export CC=clang
+            export PATH="$PWD/build:$PATH"
           '';
         };
       }


### PR DESCRIPTION
added `build` dir to path, can run `daisyc` instead of `./build/daisyc` now